### PR TITLE
update lib for search&export

### DIFF
--- a/lib/raw.js
+++ b/lib/raw.js
@@ -79,13 +79,20 @@ Raw.prototype.process = function (pdf_path, options) {
 					self.emit("error", { error: err, pdf_path: pdf_path });
 					return;
 				}
-				var pdf_first_three_pages =
+				// Extract 3 pages by default unless specified explicitly to extract all pages in a PDF.
+				var pdf_pages_to_extract =
 					pdf_files.length > 3 ? pdf_files.slice(0, 3) : pdf_files;
+				if (
+					options.hasOwnProperty("extractAllPages") &&
+					options.extractAllPages
+				) {
+					pdf_pages_to_extract = pdf_files;
+				}
 				var index = 0;
 				var single_page_pdf_file_paths = [];
-				var num_pages = pdf_first_three_pages.length;
+				var num_pages = pdf_pages_to_extract.length;
 				async.forEachSeries(
-					pdf_first_three_pages,
+					pdf_pages_to_extract,
 					// extract the text for each page via ocr
 					function (pdf_file, cb) {
 						var quality = 300;


### PR DESCRIPTION
PDF OCR for search & export

Update the pdf-extract lib to extract all pages for Search & Export PDF OCR and extract only the first 3 pages for the existing OCR workflow for Governors' offices (CA & TX).